### PR TITLE
Path 7/create sqs for user creation

### DIFF
--- a/terraform/create-user-module/main.tf
+++ b/terraform/create-user-module/main.tf
@@ -28,3 +28,10 @@ resource "aws_lambda_function" "create-user-lambda" {
     Environment = var.Environment
   }
 }
+
+resource "aws_lambda_event_source_mapping" "create-user-event-source-mapping" {
+  event_source_arn = module.create-user-queue.create-user-queue-arn
+  function_name = aws_lambda_function.create-user-lambda.function_name
+  enabled = true
+  batch_size = 10
+}

--- a/terraform/create-user-module/main.tf
+++ b/terraform/create-user-module/main.tf
@@ -4,9 +4,17 @@ module "users-database-table" {
   Region = var.Region
 }
 
+module "create-user-queue" {
+  source = "./modules/queue"
+  Environment = var.Environment
+  Region = var.Region
+}
+
 module "create-user-lambda-role" {
   source = "./modules/iam-policies"
   dynamoDB-users-table-arn = module.users-database-table.dynamoDB-users-table-arn
+  create-user-queue-arn = module.create-user-queue.create-user-queue-arn
+  Environment = var.Environment
 }
 
 resource "aws_lambda_function" "create-user-lambda" {

--- a/terraform/create-user-module/modules/iam-policies/main.tf
+++ b/terraform/create-user-module/modules/iam-policies/main.tf
@@ -19,9 +19,18 @@ data "aws_iam_policy_document" "create-user-lambda-policy" {
     ]
     resources = [var.dynamoDB-users-table-arn]
   }
+  statement {
+    effect = "Allow"
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage"
+    ]
+    resources = [var.create-user-queue-arn]
+  }
 }
 
 resource "aws_iam_policy" "create-user-lambda-policy" {
+  name = format("create-user-lambda-%s", var.Environment)
   policy = data.aws_iam_policy_document.create-user-lambda-policy.json
 }
 

--- a/terraform/create-user-module/modules/iam-policies/main.tf
+++ b/terraform/create-user-module/modules/iam-policies/main.tf
@@ -23,7 +23,8 @@ data "aws_iam_policy_document" "create-user-lambda-policy" {
     effect = "Allow"
     actions = [
       "sqs:ReceiveMessage",
-      "sqs:DeleteMessage"
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes"
     ]
     resources = [var.create-user-queue-arn]
   }

--- a/terraform/create-user-module/modules/queue/main.tf
+++ b/terraform/create-user-module/modules/queue/main.tf
@@ -1,0 +1,25 @@
+locals {
+  queue-name = "create-user-queue"
+  max-message-size = 2048
+}
+
+resource "aws_sqs_queue" "create-user-queue-dlq" {
+  name = format("%s-dlq", local.queue-name)
+  max_message_size = local.max-message-size
+  message_retention_seconds = 1209600
+}
+
+resource "aws_sqs_queue" "create-user-queue" {
+  name                      = local.queue-name
+  max_message_size          = local.max-message-size
+  message_retention_seconds = 1209600
+  receive_wait_time_seconds = 10
+  redrive_policy            = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.create-user-queue-dlq.arn
+    maxReceiveCount     = 3
+  })
+
+  tags = {
+    Environment = var.Environment
+  }
+}

--- a/terraform/create-user-module/modules/queue/outputs.tf
+++ b/terraform/create-user-module/modules/queue/outputs.tf
@@ -1,0 +1,3 @@
+output "create-user-queue-arn" {
+  value = aws_sqs_queue.create-user-queue.arn
+}

--- a/terraform/create-user-module/modules/queue/variables.tf
+++ b/terraform/create-user-module/modules/queue/variables.tf
@@ -3,10 +3,7 @@ variable "Environment" {
   type = string
 }
 
-variable "dynamoDB-users-table-arn" {
-  type = string
-}
-
-variable "create-user-queue-arn" {
+variable "Region" {
+  description = "Region for the infrastructure. Example: eu-central-1"
   type = string
 }


### PR DESCRIPTION
This PR creates the terraforming script for an [AWS SQS](https://aws.amazon.com/sqs/), which is a simple queue system. 

It also creates an `event source mapping` between the SQS and the previously created Lambda. This is essentially a 'trigger', which sends the message from the queue to the lambda, which consumes the message. 